### PR TITLE
[feat]#67-감정원인만 출력하도록 후처리 함수 추가

### DIFF
--- a/src/backend/ai/sentiment_cause/inference/inference.py
+++ b/src/backend/ai/sentiment_cause/inference/inference.py
@@ -21,9 +21,11 @@ def preprocess_user_input(text):
     sentences = re.split(r'(?<=[.!?])\s+', text)      # 문장 단위로 분리
     return [s for s in sentences if len(s) > 5]       # 너무 짧은 문장 제외
 
-# 출력 후처리 함수
+# 출력 후처리 함수 (감정 제거 → 원인만 반환)
 def clean_output(text):
     text = re.sub(r"[\"\'\[\]\(\)]", "", text).strip()
+    if "||" in text:
+        text = text.split("||", 1)[1]  # 감정 제거
     if len(text) < 2 or text.lower() in ["none", "nan", "감정"]:
         return ""
     return text


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

로컬 디렉토리에 캐시가 남아있어서 감정||원인 형태로 출력하여 원인만 출력할 수 있도록 후처리 함수 추가했습니다.

## 🖥️ 주요 코드 설명

```language
def clean_output(text):
    text = re.sub(r"[\"\'\[\]\(\)]", "", text).strip()
    if "||" in text:
        text = text.split("||", 1)[1]  # 감정 제거
    if len(text) < 2 or text.lower() in ["none", "nan", "감정"]:
        return ""
    return text
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가요?
- [x] 최종 코드가 에러 없이 잘 동작하나요?

## 📟 관련 이슈

- #67 
